### PR TITLE
Update TOC.yml

### DIFF
--- a/documentation/Service-Agreements-and-Guarantees/Product-Service-Agreement/TOC.yml
+++ b/documentation/Service-Agreements-and-Guarantees/Product-Service-Agreement/TOC.yml
@@ -170,5 +170,4 @@ items:
     href: Voucher-Terms-Of-Service.md
   - name: 京东云推荐返利协议
     href: Recommended-Rebate-User-Agreement.md
-  - name: 京东云认证考试服务协议
-    href: JDCloud-Technical-Training-and-Certification-Terms-Of-Service.md   
+


### PR DESCRIPTION
由于京东云技术课程培训及认证没有上线，去掉toc里信息