### PR TITLE
virtual-machines/ssh-login-error-service-sshd,ssh-login-reported-must-be-owned-by-root-and-not-group-or-word-writable,ssh-connection-error更新

### DIFF
--- a/documentation/Elastic-Compute/Virtual-Machines/Linux-Troubleshooting/Fault-Class/SSH-connection-error.md
+++ b/documentation/Elastic-Compute/Virtual-Machines/Linux-Troubleshooting/Fault-Class/SSH-connection-error.md
@@ -6,55 +6,60 @@
 
 
 
-**问题描述：**
+## **问题描述：**
 
 当使用 SSH 登录 Linux 云主机时，即便正确输入了密码，在命令行或 secure 日志中也会出现类似如下错误信息，导致连接失败：
 
-*Permission denied, please try again.*
+```shell
+Permission denied, please try again.
+error: Could not get shadow infromation for root.
+```
 
-*error: Could not get shadow infromation for root.*
 
 
-
-**问题原因：**
+## **问题原因：**
 
 该问题通常是由于系统启用了 SELinux 所致。
 
 
 
-**处理办法：**
+## **处理办法：**
 
-查看 SELinux 状态
+### 查看 SELinux 状态
 
 1.通过 vnc 进入系统
 
 2.使用如下指令查看当前SELinux运行状态：
 
-
-*/usr/sbin/sestatus  -v*
+```shell
+/usr/sbin/sestatus  -v
+```
 
 执行结果 
 
-*SELinux status:                 enabled*
+```shell
+SELinux status:	enabled
+```
 
 如果 status 值为 enabled，则说明已经启用了 SELinux。
 
 
 
-临时关闭 SELinux 
+### 临时关闭 SELinux 
 
 1.通过 vnc 进入系统
 
 2.使用如下指令临时关闭SELinux：
 
-
-*setenforce 0*
+```shell
+#setenforce 0
+```
 
 3.从客户端再次尝试连接服务器。如果能正常登录，则确认是SELinux配置导致的问题。如果还是无法正常登录，则需要继续排查分析。
 
 
 
-永久关闭 SELinux
+### 永久关闭 SELinux
 
 1.通过 vnc 进入系统
 
@@ -62,8 +67,9 @@
 
 3.使用 vi 等编辑器，编辑 /etc/selinux/config 文件，修改或进行如下设置：
 
-
-*SELINUX=disabled*
+```shell
+SELINUX=disabled
+```
 
 4.重启服务器，用以永久禁用SELinux
 

--- a/documentation/Elastic-Compute/Virtual-Machines/Linux-Troubleshooting/Fault-Class/SSH-login-error-service-sshd.md
+++ b/documentation/Elastic-Compute/Virtual-Machines/Linux-Troubleshooting/Fault-Class/SSH-login-error-service-sshd.md
@@ -1,31 +1,31 @@
 # SSH 登录时出现如下错误：pam_listfile(sshd:auth): Refused user root for service sshd
 
-
-
 注意：本文相关 Linux 配置及说明已在 CentOS 6.5 64 位操作系统中进行过测试。其它类型及版本操作系统配置可能有所差异，具体情况请参阅相应操作系统官方文档。
 
 
 
-**问题描述：**
+## **问题描述：**
 
 
 登录 Linux 云主机时，即便输入了正确的密码，也无法正常登录。该问题出现时，控制台 vnc 或 SSH 客户端其中一种方式可以正常登录，或者两种方式均无法正常登录。同时，/var/log/secure 日志中出现类似如下错误信息：
 
-*sshd[1199]: pam_listfile(sshd:auth): Refused user root for service sshd*
+```shell
+sshd[1199]: pam_listfile(sshd:auth): Refused user root for service sshd*
 
-*sshd[1199]: Failed password for root from 192.168.0.1 port 22 ssh2*
+sshd[1199]: Failed password for root from 192.168.0.1 port 22 ssh2*
 
-*sshd[1204]: Connection closed by 192.168.0.2*
+sshd[1204]: Connection closed by 192.168.0.2
+```
 
 
 
-**问题原因：**
+## **问题原因：**
 
 PAM 模块 pam_listfile.so 相关访问控制策略导致用户登录失败。
 
 
 
-**处理方法：**
+## **处理方法：**
 
 pam_listfile.so 模块可用于 Linux 访问控制。要解决此问题，请进行如下配置检查：
 
@@ -33,7 +33,7 @@ pam_listfile.so 模块可用于 Linux 访问控制。要解决此问题，请进
 
 2.通过 cat 等指令查看异常登录模式，对应的 PAM 配置文件。说明如下：
 
-文件	功能说明
+​	文件							功能说明
 
 */etc/pam.d/login*	控制台（vnc）对应配置文件
 
@@ -43,12 +43,11 @@ pam_listfile.so 模块可用于 Linux 访问控制。要解决此问题，请进
 
 注意：每个启用了 PAM 的应用程序，在 /etc/pam.d 目录中都有对应的同名配置文件。例如，login 命令的配置文件是 /etc/pam.d/login，可以在相应配置文件中配置具体的策略。
 
-
-
 3.检查前述配置文件中，是否有类似如下配置信息：
 
-
-*auth required pam_listfile.so item=user sense=allow file=/etc/ssh/whitelist onerr=fail*
+```shell
+auth required pam_listfile.so item=user sense=allow file=/etc/ssh/whitelist onerr=fail
+```
 
 相关参数简要说明：
 
@@ -60,19 +59,19 @@ file：用于指定配置文件的全路径名称。
 
 onerr：定义了出现错误（比如无法打开配置文件）时的缺省返回值。
 
-
-
 4.相关策略可以提高服务器的安全性。请用户基于安全性和易用性权衡后，再确定是否需要修改相关配置。
 
 5.如果需要修改相关策略配置，在继续之前建议进行文件备份。
 
 6.使用 vi 等编辑器，按需修改相关参数值，确认对应的访问控制文件中，已经对相应用户做了访问放行。或者整个删除或注释（在最开头添加 # 号）整行配置：
 
-
-*#auth required pam_listfile.so item=user sense=allow file=/etc/ssh/whitelist onerr=fail*
+```shell
+#auth required pam_listfile.so item=user sense=allow file=/etc/ssh/whitelist onerr=fail
+```
 
 7.尝试重新登录服务器。
 
 
 
 如无法解决您的问题，请向我们提工单。
+

--- a/documentation/Elastic-Compute/Virtual-Machines/Linux-Troubleshooting/Fault-Class/SSH-login-reported-must-be-owned-by-root-and-not-group-or-word-writable.md
+++ b/documentation/Elastic-Compute/Virtual-Machines/Linux-Troubleshooting/Fault-Class/SSH-login-reported-must-be-owned-by-root-and-not-group-or-word-writable.md
@@ -7,23 +7,24 @@
 
 
 
-**问题现象**
+## **问题现象**
 
 Linux 云主机启动 SSH 服务时，出现类似如下错误信息：
 
-*• /var/empty/sshd must be owned by root and not group or word-writable.*
+```shell
+• /var/empty/sshd must be owned by root and not group or word-writable.
 
+```
 
-
-**问题原因**
+## **问题原因**
 
 SSH 服务基于安全性考虑，对服务相关的目录或文件的权限配置、属组等都有要求。该问题通常是由于相关权限或属组设置异常所致。
 
 
 
-**处理办法**
+## **处理办法**
 
-**方法一：/var/empty/sshd 目录配置**
+### **方法一：/var/empty/sshd 目录配置**
 
 
 /var/empty/sshd 目录权限默认为 711，默认属组为root:root。要解决此问题，请进行如下配置检查或修改：
@@ -32,30 +33,32 @@ SSH 服务基于安全性考虑，对服务相关的目录或文件的权限配�
 
 2.通过如下指令查看 /var/empty/sshd/ 目录的权限配置：
 
-
-*ll -d /var/empty/sshd/*
+```shell
+ll -d /var/empty/sshd/
+```
 
 默认配置：
 
-*drwx--x--x. 2 root root 4096 Nov 23  2013 /var/empty/sshd/*
-
-
+```shell
+drwx--x--x. 2 root root 4096 Nov 23  2013 /var/empty/sshd/
+```
 
 3.如果默认权限或属组被修改，则可以通过如下指令进行修改：
 
+```shell
+chown -R root.root /var/empty/sshd 
 
-*chown -R root.root /var/empty/sshd* 
-
-*chmod -R 711 /var/empty/sshd*
+chmod -R 711 /var/empty/sshd
+```
 
 
 4.使用如下指令，重启 SSH 服务，验证服务可否正常启动：
 
+```shell
+service sshd restart
+```
 
-*service sshd restart*
-
-
-**方法二：/etc/securetty 目录配置问题**
+### **方法二：/etc/securetty 目录配置问题**
 
 /etc/securetty 目录权限配置默认为 600，默认属组为root:root。要解决此问题，请进行如下配置检查或修改：
 
@@ -63,26 +66,32 @@ SSH 服务基于安全性考虑，对服务相关的目录或文件的权限配�
 
 2.通过如下指令查看 /etc/securetty 目录的权限配置：
 
-
-*ll /etc/securetty*
+```shell
+ll /etc/securetty
+```
 
 默认配置：
 
-*-rw-------. 1 root root 122 Jan 12  2010 /etc/securetty*
+```shell
+-rw-------. 1 root root 122 Jan 12  2010 /etc/securetty
+```
 
 
 3.如果默认权限或属组被修改，则可以通过如下指令进行修改：
 
+```shell
+chown root.root /etc/securetty
 
-*chown root.root /etc/securetty*
-
-*chmod 600 /etc/securetty*
+chmod 600 /etc/securetty
+```
 
 
 4.使用如下指令，重启 SSH 服务，验证服务可否正常启动：
 
-
-*service sshd restart*
+```
+service sshd restart
+```
 
 
 如无法解决您的问题，请向我们提工单。
+


### PR DESCRIPTION
virtual-machines/ssh-login-error-service-sshd,ssh-login-reported-must-be-owned-by-root-and-not-group-or-word-writable,ssh-connection-error更新